### PR TITLE
Add core_ext for TrueClass and FalseClass

### DIFF
--- a/lib/hashr.rb
+++ b/lib/hashr.rb
@@ -1,4 +1,6 @@
 require 'hashr/core_ext/ruby/hash'
+require 'hashr/core_ext/ruby/true_class'
+require 'hashr/core_ext/ruby/false_class'
 
 class Hashr < Hash
   autoload :EnvDefaults, 'hashr/env_defaults'

--- a/lib/hashr/core_ext/ruby/false_class.rb
+++ b/lib/hashr/core_ext/ruby/false_class.rb
@@ -1,0 +1,5 @@
+class FalseClass
+  def to_sym
+    to_s.to_sym
+  end
+end

--- a/lib/hashr/core_ext/ruby/true_class.rb
+++ b/lib/hashr/core_ext/ruby/true_class.rb
@@ -1,0 +1,5 @@
+class TrueClass
+  def to_sym
+    to_s.to_sym
+  end
+end


### PR DESCRIPTION
This adds the to_sym method to TrueClass and Falseclass, as they can
appear in a hash.