### PR TITLE
Use Minitest 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 PATH
   remote: .
   specs:
-    hashr (0.0.20)
+    hashr (0.0.22)
 
 GEM
   remote: http://rubygems.org/
   specs:
+    minitest (5.3.4)
     rake (0.9.2)
     test_declarative (0.0.5)
 
@@ -15,5 +16,6 @@ PLATFORMS
 
 DEPENDENCIES
   hashr!
+  minitest (>= 5.0.0)
   rake
   test_declarative (>= 0.0.2)

--- a/hashr.gemspec
+++ b/hashr.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'test_declarative', '>=0.0.2'
+  s.add_development_dependency 'minitest', '>=5.0.0'
 end

--- a/test/core_ext_test.rb
+++ b/test/core_ext_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CoreExtTest < Test::Unit::TestCase
+class CoreExtTest < Minitest::Test
   test 'Hash#deep_symbolize_keys walks arrays, too' do
     hash     = { 'foo' => [{ 'bar' => 'bar', 'baz' => { 'buz' => 'buz' } }] }
     expected = { :foo  => [{ :bar  => 'bar', :baz  => { :buz  => 'buz' } }] }

--- a/test/hashr_test.rb
+++ b/test/hashr_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
-class HashrTest < Test::Unit::TestCase
+class HashrTest < Minitest::Test
   def teardown
     Hashr.raise_missing_keys = false
   end
 
   test 'initialize takes nil' do
-    assert_nothing_raised { Hashr.new(nil) }
+    Hashr.new(nil)
   end
 
   test 'method access on an existing key returns the value' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
 require 'bundler/setup'
-require 'test/unit'
+require 'minitest/autorun'
 require 'test_declarative'
 require 'hashr'


### PR DESCRIPTION
Ruby won't include `test/unit` anymore so it's probably time to move on to minitest 5. I created this patch as we already updated minitest in Fedora because of Rails 4.1.
